### PR TITLE
remove jsx transformer dependency

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
     <script type="text/javascript" src="bower_components/lodash/dist/lodash.min.js"></script>
     <script type="text/javascript" src="bower_components/underscore.string/dist/underscore.string.min.js"></script>
     <script type="text/javascript" src="bower_components/react/react.js"></script>
-    <script type="text/javascript" src="bower_components/react/JSXTransformer.js"></script>
-    <script type="text/jsx" src="dist/app.js"></script>
+    <script type="text/javascript" src="dist/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The script type of 'text/jsx' invokes JSXTransformer in the browser, which is not required because the jsx is already precompiled with browserify by gulp.